### PR TITLE
Remove pointless images in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ The data from the API is offered under the [Open Data License Agreement v1.0](ht
 
 ## Contact ##
 
-If you have any inquiries or suggestions, please feel free to contact us at:
-
-[opendata.api@uwaterloo.ca](mailto:opendata.api@uwaterloo.ca)
+If you have any inquiries or suggestions, please feel free to contact us at [opendata.api@uwaterloo.ca](mailto:opendata.api@uwaterloo.ca).
 
 Please consider subscribing to our [mailing list](https://lists.uwaterloo.ca/mailman/listinfo/opendata) in order to receive updates on the API and follow discussions.


### PR DESCRIPTION
For some reason, the email address and Mailman URL in README.md are images instead of text. This is absolutely pointless, as in both cases they are links to the things in the image.

My best guess is that this was intended as a defence against crawlers. But crawlers understand the href attribute of a link just fine.

All this does is make the page marginally slower and inaccessible to users of screen readers.

This pull request removes the email address image and replaces it with plain text, and removes the Mailman URL altogether (since a link is in the immediately preceding paragraph already).
